### PR TITLE
Correct Grid Garden and Flexbox guide links

### DIFF
--- a/content/blog/episode/css-part-2.md
+++ b/content/blog/episode/css-part-2.md
@@ -62,8 +62,8 @@ draft: false
 ## Resources
 
 - <a target="_blank" href="https://flexboxfroggy.com/">Flexbox Froggy</a>
-- <a target="_blank" href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">Grid Garden</a>
-- <a target="_blank" href="https://cssgridgarden.com/">CSS Tricks a Complete Guide To Flexbox</a>
+- <a target="_blank" href="https://cssgridgarden.com/">Grid Garden</a>
+- <a target="_blank" href="https://css-tricks.com/snippets/css/a-guide-to-flexbox"/>CSS Tricks a Complete Guide To Flexbox</a>
 - <a target="_blank" href="https://css-tricks.com/snippets/css/complete-guide-grid/">CSS Tricks A Complete Guide To Grid</a>
 - <a target="_blank" href="https://levelup.gitconnected.com/when-to-use-css-flexbox-vs-grid-or-both-c1a5f01dc88a">CSS Flexbox vs. CSS Grid</a>
 - <a target="_blank" href="http://www.flexboxdefense.com/">Flexbox Defense</a>

--- a/content/blog/episode/css-part-2.md
+++ b/content/blog/episode/css-part-2.md
@@ -63,7 +63,7 @@ draft: false
 
 - <a target="_blank" href="https://flexboxfroggy.com/">Flexbox Froggy</a>
 - <a target="_blank" href="https://cssgridgarden.com/">Grid Garden</a>
-- <a target="_blank" href="https://css-tricks.com/snippets/css/a-guide-to-flexbox"/>CSS Tricks a Complete Guide To Flexbox</a>
+- <a target="_blank" href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">CSS Tricks a Complete Guide To Flexbox</a>
 - <a target="_blank" href="https://css-tricks.com/snippets/css/complete-guide-grid/">CSS Tricks A Complete Guide To Grid</a>
 - <a target="_blank" href="https://levelup.gitconnected.com/when-to-use-css-flexbox-vs-grid-or-both-c1a5f01dc88a">CSS Flexbox vs. CSS Grid</a>
 - <a target="_blank" href="http://www.flexboxdefense.com/">Flexbox Defense</a>


### PR DESCRIPTION
Found this whilst I was trying to play Grid Garden after listening to the episode! The "Grid Garden" and "CSS Tricks a Complete Guide To Flexbox" links are in the wrong order, so here's a small fix to correct them :)