### PR TITLE
Added Github Repo Link on Nav with Icon

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -5,6 +5,7 @@ import {
   FaSpotify,
   FaItunes,
   FaTwitter,
+  FaGithubAlt,
   FaRss,
   FaPodcast,
 } from "react-icons/fa"
@@ -31,6 +32,13 @@ export default () => (
         rel="noopener noreferrer"
       >
         <FaTwitter size="1.6em" title="Follow on Twitter" />
+      </a>
+      <a
+        href="https://github.com/ladybug-podcast/ladybugpodcast.git"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FaGithubAlt size="1.6em" title="Follow our Development on Github" />
       </a>
       <a
         href="https://podcasts.apple.com/us/podcast/ladybug-podcast/id1469229625"


### PR DESCRIPTION
#### What's this PR do?
- Added Font awesome Github Alt icon
- Added link to this repo
- Fixes the issue of not having a Github repo link in the navigation bar
#### Where should the reviewer start?
- Run the page and check if the github icon appears and if the link works correctly
#### How should this be manually tested?
- Manually go to the page and test the icon/link
#### Any background context you want to provide?
- None
#### What are the relevant tickets?
- Fixes issue #57 [https://github.com/ladybug-podcast/ladybugpodcast/issues/57]



