### PR TITLE
Escape special characters on the title for twitter sharing

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -17,7 +17,9 @@ class BlogPostTemplate extends React.Component {
       post.frontmatter.title
     }, a @LadybugPodcast episode by @kvlly, @emmawedekind, and @aspittel!`
     const shareUrl = `https://ladybug.dev/episode/${post.frontmatter.slug}`
-    const twitterShare = `//twitter.com/share?text=${shareTitle}&amp;url=${shareUrl}`
+    const twitterShare = `//twitter.com/share?text=${encodeURIComponent(
+      shareTitle
+    )}&amp;url=${shareUrl}`
 
     return (
       <Layout location={this.props.location} title={siteTitle}>


### PR DESCRIPTION
Hi, in the last episode https://ladybug.dev/episode/javascript-frameworks/ when I click the twitter share button it cuts off the title because of the '&' characters in the title of this episode. See image below.

![image](https://user-images.githubusercontent.com/5277142/66812034-6b5a6400-ef32-11e9-8b6c-5c1328ecd2d9.png)

I added this encodeURIComponent(shareTitle) function to change the characters to the correct url friendly values. Initially I thought shareTitle.replace(/&/g,'%26') would be fine but what about other characters in titles like hash tags and etc.

After the fix

![image](https://user-images.githubusercontent.com/5277142/66812282-e1f76180-ef32-11e9-847e-7f41190f6f60.png)

